### PR TITLE
Prevent additionalProperties in api gateway schemas

### DIFF
--- a/packages/serverless-contracts/contracts/apiGateway/__tests__/httpApiContract.test.ts
+++ b/packages/serverless-contracts/contracts/apiGateway/__tests__/httpApiContract.test.ts
@@ -85,6 +85,7 @@ describe('httpApiContract', () => {
           'headers',
           'body',
         ],
+        additionalProperties: false,
       });
     });
 
@@ -117,6 +118,7 @@ describe('httpApiContract', () => {
           'body',
           'output',
         ],
+        additionalProperties: false,
       });
     });
 

--- a/packages/serverless-contracts/contracts/apiGateway/__tests__/restApiContract.test.ts
+++ b/packages/serverless-contracts/contracts/apiGateway/__tests__/restApiContract.test.ts
@@ -48,6 +48,7 @@ describe('restApiContract', () => {
         type: 'object',
         properties: {},
         required: [],
+        additionalProperties: false,
       });
     });
 
@@ -61,6 +62,7 @@ describe('restApiContract', () => {
           method: { const: 'POST' },
         },
         required: ['contractId', 'contractType', 'path', 'method'],
+        additionalProperties: false,
       });
     });
 

--- a/packages/serverless-contracts/contracts/apiGateway/apiGatewayContract.ts
+++ b/packages/serverless-contracts/contracts/apiGateway/apiGatewayContract.ts
@@ -166,6 +166,7 @@ export class ApiGatewayContract<
       properties,
       // @ts-ignore here object.keys is not precise enough
       required: Object.keys(properties),
+      additionalProperties: false,
     };
   }
 
@@ -220,6 +221,7 @@ export class ApiGatewayContract<
       properties,
       // @ts-ignore type inference does not work here
       required: Object.keys(properties),
+      additionalProperties: false,
     };
   }
 

--- a/packages/serverless-contracts/contracts/apiGateway/types.ts
+++ b/packages/serverless-contracts/contracts/apiGateway/types.ts
@@ -130,6 +130,7 @@ export type InputSchemaType<
   type: 'object';
   properties: DefinedInputProperties;
   required: Array<keyof DefinedInputProperties>;
+  additionalProperties: false;
 };
 
 /**
@@ -162,6 +163,7 @@ export interface FullContractSchemaType<
   type: 'object';
   properties: DefinedFullContractProperties;
   required: Array<keyof DefinedFullContractProperties>;
+  additionalProperties: false;
 }
 
 /**


### PR DESCRIPTION
Prevent having unknown keys to infered types:


```typescript
const bodySchema = {
  type: 'object',
  properties: {
    productId: { type: 'string' },
  },
  required: ['productId'],
  additionalProperties: false,
} as const;

const createRentalContract = new ApiGatewayContract({
  id: 'users-getUser',
  path: '/checkout/rentals',
  method: 'POST',
  integrationType: 'httpApi',
  pathParametersSchema: undefined,
  queryStringParametersSchema: undefined,
  bodySchema,
  headersSchema: undefined,
  outputSchema: undefined,
});

export type CreateRentalContractInput = FromSchema<typeof createRentalContract.inputSchema>;

// before
type CreateRentalContractInput = {
    [x: string]: unknown;
    body: {
        productId: string;
    };
}

// after
type CreateRentalContractInput = {
    body: {
        productId: string;
    };
}
```